### PR TITLE
Fix empty task

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,10 +3,11 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/oussamaM1/task/models"
 	"github.com/oussamaM1/task/services"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 var addCommand = &cobra.Command{
@@ -22,6 +23,12 @@ func init() {
 func add(cmd *cobra.Command, args []string) {
 	services.LogInfo("Command called: %s", cmd.Name())
 	services.LogInfo("Arguments: %s", strings.Join(args, " "))
+
+	if len(args) == 0 {
+		fmt.Println("No description entered for task")
+		return
+	}
+
 	var id int = services.GenerateNewID()
 	var taskList []models.Task
 	for _, arg := range args {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/oussamaM1/task
 go 1.22
 
 require (
+	github.com/jedib0t/go-pretty/v6 v6.5.6
 	github.com/joho/godotenv v1.5.1
 	github.com/spf13/cobra v1.8.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -10,7 +11,6 @@ require (
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jedib0t/go-pretty/v6 v6.5.6 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect


### PR DESCRIPTION
Hi,

Running `task add` creates an empty task. Task won't be able to manipulate the todos.txt file anymore if it's the first task.

This little fix prevents this.

